### PR TITLE
Add Play privacy disclosures

### DIFF
--- a/PRIVACY.md
+++ b/PRIVACY.md
@@ -1,89 +1,295 @@
-# Privacy and Data Handling
+# Twidget Privacy Policy
 
-This document describes the behavior of the open-source Twidget app and bridge.
-An operator who deploys a modified or self-hosted bridge is responsible for
-describing any different practices.
+**Effective date:** 26 July 2026
+**Last updated:** 26 July 2026
 
-## Data stored on the Android device
+This Privacy Policy explains how **Twidget** (`com.tjg.twidget`) accesses,
+uses, stores, transmits, and deletes information. Twidget is developed and
+published by **That Josh Guy**.
 
-Twidget stores configured X/Twitter usernames, app and widget preferences,
-fetched profile statistics, post analytics, local history, and locally created
-scheduled-post drafts on the device. Drafts may include persisted references to
-media selected through Android's system picker. Optional official X API
-credentials, self-hosted bridge tokens, cached bearer tokens, Buffer OAuth
-tokens, and a user-supplied TwitterAPIs API key are protected using Android
-Keystore-backed encryption.
+Twidget is an independent app for viewing public X/Twitter account statistics,
+displaying widgets, importing account analytics, finding top followers, and
+optionally preparing or scheduling posts. It is not affiliated with X Corp.,
+Buffer, Cloudinary, Google, Samsung, or the other services named below.
 
-Android cloud backup is disabled for the app. Removing an account from Twidget
-removes its app-managed local profile and history. Uninstalling the app removes
-its app-private data under normal Android behavior.
+## Summary
 
-## Network requests
+- Twidget does not sell personal data.
+- Twidget contains no advertising, behavioural tracking, third-party analytics,
+  or crash-reporting SDK.
+- Most app data is stored only on the device. Android cloud backup and
+  device-to-device transfer are disabled for Twidget's private data.
+- Network features send information only to the service needed to perform the
+  feature selected by the user.
+- Contributing public account history to the Twidget bridge is optional and is
+  off by default.
+- Twidget does not create a Twidget user account. Users may optionally connect
+  an existing Buffer account for scheduling.
 
-The selected data source determines where requests go:
+## Information stored on the device
 
-- **FxTwitter:** the app contacts FxTwitter directly for public profile and
-  recent-post information.
-- **Shared Twidget bridge:** the app contacts the hosted bridge when that source
-  is selected or when shared history has been explicitly enabled.
-- **Self-hosted bridge:** the app contacts the URL configured by the user.
-- **Official X API:** the app contacts X directly using credentials supplied by
-  the user.
-- **TwitterAPIs:** when a top-followers scan is manually started, the app sends
-  the selected public X/Twitter username directly to TwitterAPIs using either
-  Twidget's included trial key or a user-supplied key. Selecting TwitterAPIs as
-  the profile data source requires a user-supplied key. Personal keys are
-  encrypted at rest and take priority over the included key. Profile results
-  and resumable scan progress remain on-device, and API keys are never sent
-  through the Twidget bridge. When shared history is enabled, only the completed
-  public Top Followers ranking and its scan metadata may be contributed to the
-  bridge as described below.
-- **Buffer scheduling:** after the user authorizes Twidget with Buffer OAuth,
-  the app uploads device-local attachments for posts explicitly saved or
-  scheduled with Buffer to the app maintainer's Cloudinary account, then sends
-  the text, publishing time, selected Buffer X channel, and resulting public
-  media URLs to Buffer. OAuth access
-  and refresh tokens stay encrypted on the device. Local reminder drafts are
-  not sent to Buffer.
-- **Updates:** the About screen checks this repository's GitHub Releases API;
-  update downloads come from the matching GitHub release asset.
-- **Images and links:** profile images may be fetched from URLs returned by a
-  provider or from Unavatar, and links opened by the user are handled by the
-  selected browser or app.
+Twidget may store the following in app-private storage:
 
-Those third-party services receive normal network metadata such as the user's
-IP address and user agent and apply their own privacy policies.
+- configured public X/Twitter usernames;
+- app, dashboard, schedule, and widget preferences;
+- public profile information and statistics returned by the selected provider,
+  including display name, username, avatar URL, follower and following counts,
+  post counts, likes, verification status, and protected-account status;
+- local history samples and cached recent-post analytics;
+- imported X Analytics movements and metrics;
+- Top Followers scan results and resumable scan progress;
+- locally created post drafts, reminders, publishing state, and references to
+  media explicitly selected through Android's system picker;
+- optional self-hosted bridge settings and local diagnostic logs enabled
+  through the hidden debug menu.
 
-## Shared history
+Optional official X API credentials, self-hosted bridge tokens, cached bearer
+tokens, Buffer OAuth tokens, and a user-supplied TwitterAPIs key are protected
+with Android Keystore-backed encryption.
 
-Shared history is opt-in. Ordinary direct FxTwitter lookups do not register an
-account in the hosted history pool. When sharing is enabled, the bridge may
-store the X/Twitter username, public account metrics, metric provenance, and
-daily sample timestamps so participating users can receive real historical
-data. A completed Top Followers scan may also contribute the five public
-accounts in its ranking, their public profile fields, and scan metadata; other
-participating installs can reuse that result. Non-participating installs do
-not upload or request shared Top Followers results. Client-supplied historical
-backfill is disabled by default.
+Local data remains until it is replaced, removed using the relevant app
+control, cleared through Android, or removed when the app is uninstalled.
+Removing a tracked account from Twidget removes its app-managed local profile
+and history. Cached images and other temporary files may be removed by Android
+or by clearing the app's cache.
 
-The bridge can use PostgreSQL for history and Redis for shared request limits,
-caches, registration budgets, and scheduled-job locks. Retention and inactive
-account deletion are operator-configured. Operators can delete an account's
-stored history through the protected administration endpoint.
+## Information transmitted off the device
 
-Do not submit secrets or private account content to the shared-history service.
-The bridge is designed around public profile metrics and does not need a user's
-X password.
+The information sent depends on the feature and data source chosen.
 
-## Logs and operational data
+### Public X/Twitter account lookups
 
-The hosted platform and bridge may process short-lived request metadata,
-errors, health information, and abuse-prevention counters needed to operate and
-secure the service. Application debug logs are stored locally and are not
-uploaded automatically.
+To retrieve public account information, Twidget sends the configured public
+X/Twitter username to one or more of the following, depending on the selected
+source and fallback configuration:
 
-## Questions and deletion requests
+- FxTwitter/FxEmbed;
+- the maintainer-operated Twidget bridge;
+- a bridge URL configured by the user;
+- X's official API using credentials supplied by the user; or
+- TwitterAPIs using a user-supplied key.
 
-For privacy questions or deletion of history held by the maintainer-operated
-bridge, contact the maintainer through [tjg.gg](https://tjg.gg) and identify the
-X/Twitter username to remove. Do not send API keys, passwords, or bridge tokens.
+These requests return public profile fields, statistics, posts, and media
+needed for the dashboard and widgets. Providers also receive ordinary network
+information such as the IP address and user agent.
+
+### Shared history and Top Followers
+
+Shared history is optional and off by default. When enabled, the
+maintainer-operated Twidget bridge may store:
+
+- the tracked public X/Twitter username;
+- public follower, following, post, and like counts;
+- sample dates, timestamps, and metric provenance;
+- verified movements derived from an X Analytics import, including dates and
+  follow/unfollow counts; and
+- a completed Top Followers ranking containing up to five public accounts,
+  their public names, usernames, account IDs, follower counts, verification
+  state, avatar URLs, and scan metadata.
+
+This information is pooled so participating Twidget users can receive genuine
+historical samples or reuse a completed public ranking. Ordinary direct
+FxTwitter lookups do not register an account in the shared-history pool.
+Private accounts are not accepted into the pool.
+
+The bridge may use PostgreSQL for history and Redis for short-lived caches,
+request limits, registration limits, and scheduled-job locks.
+
+### X Analytics CSV import
+
+The selected CSV file is opened and parsed on the device. Twidget does not
+upload the original file or its file name. When a bridge-backed import is
+active, Twidget sends the tracked username and parsed dates and follow/unfollow
+movements to the configured bridge for validation. Other imported analytics
+metrics remain on the device.
+
+### Top Followers and post analytics providers
+
+When the user starts a Top Followers scan, Twidget sends the selected public
+username directly to TwitterAPIs with either the included rate-limited app key
+or a key supplied by the user. When TwitterAPIs is selected as the profile or
+post-analytics provider, the username is also sent for those requests.
+Personal provider keys remain encrypted on the device and are not sent through
+the Twidget bridge.
+
+### Buffer scheduling and Cloudinary media
+
+Buffer integration is optional. Twidget does not create a Twidget account.
+When the user connects an existing Buffer account, Buffer's OAuth service
+processes the sign-in and consent flow. Twidget stores the resulting access and
+refresh tokens in encrypted app-private storage and uses them to retrieve the
+Buffer account, organisations, X channels, drafts, and scheduled-post state.
+
+When the user explicitly saves or schedules a Buffer post, Twidget sends
+Buffer:
+
+- the selected Buffer organisation and X channel identifiers;
+- post or thread text;
+- the requested publishing time;
+- draft or scheduling state; and
+- public media URLs for any attachments.
+
+Buffer's API requires attachments to be reachable by public URL. Images or
+videos explicitly selected for a Buffer post are therefore uploaded to the
+configured Cloudinary account using its unsigned upload preset. A release may
+provide a maintainer-operated Cloudinary configuration, and users can replace
+it with their own Cloudinary cloud and preset. The upload includes the media
+content, file name, and media type. Cloudinary returns a public URL that is
+then sent to Buffer.
+
+Cloudinary-hosted media may remain available after a Buffer post or local draft
+is removed. For media uploaded to the maintainer-operated Cloudinary account,
+use the deletion process below. If the user supplied their own Cloudinary
+configuration, they control deletion and retention in that account.
+
+Local-reminder drafts and attachments are not uploaded to Buffer or Cloudinary.
+
+### Updates, images, and external links
+
+- The About screen checks the GitHub Releases API for Twidget updates. Update
+  downloads come from a matching GitHub release asset.
+- Profile and post images may be downloaded from URLs returned by a provider
+  or from Unavatar and cached on the device.
+- Links deliberately opened by the user are handled by the selected browser or
+  external app, which applies its own privacy practices.
+
+## Operational and device information
+
+The maintainer-operated bridge uses the request IP address as a short-lived
+rate-limit key to prevent abuse and protect service availability. Hosting
+providers may process request timestamps, routes, network information, errors,
+and health data for operation and security. Twidget does not use IP addresses
+to infer the user's location.
+
+The Android app's hidden debug log is disabled by default, stored only on the
+device, and never uploaded automatically.
+
+## How information is used
+
+Information is used only to:
+
+- provide dashboards, widgets, history, post insights, provider access,
+  scheduling, media upload, and update features requested by the user;
+- authenticate requests to services the user has configured;
+- maintain optional shared public history and reusable public rankings;
+- validate imported history and protect data accuracy;
+- cache results, apply provider limits, diagnose faults, secure the bridge, and
+  prevent abuse; and
+- respond to privacy and deletion requests.
+
+Twidget does not use information for advertising or cross-service behavioural
+tracking.
+
+## Sharing and service providers
+
+Information may be processed by the following categories of recipient:
+
+- public-profile and analytics providers selected by the user, including
+  FxTwitter/FxEmbed, X, TwitterAPIs, and a configured bridge operator;
+- Buffer, when the user connects Buffer or explicitly uses remote
+  draft/scheduling features;
+- Cloudinary, when the user attaches media to a Buffer post;
+- GitHub, for release checks and downloads;
+- Unavatar and image hosts, when the app retrieves an image; and
+- infrastructure providers used to host the maintainer-operated bridge and its
+  storage.
+
+Each third-party service processes information under its own terms and privacy
+policy. Twidget does not sell personal data or provide it to data brokers.
+
+## Security
+
+Built-in services use HTTPS to encrypt information in transit. Android blocks
+cleartext traffic for Twidget's target SDK by default. Sensitive credentials
+stored by the app are protected using Android Keystore-backed encryption.
+App-private cloud backup and device transfer are disabled. The bridge applies
+input validation, bounded request bodies, rate limits, access controls for
+administrative functions, and restricted retention controls.
+
+No method of transmission or storage is completely secure. Users should not
+submit X passwords, private-account content, or unrelated secrets to the
+Twidget bridge.
+
+## Retention
+
+- **On-device data:** retained until removed in the app, cleared through
+  Android, replaced by newer cached data, or deleted on uninstall.
+- **Shared bridge history:** retained according to the bridge operator's
+  configured sample-retention and inactive-account rules. The operator may
+  retain history until a deletion request when automatic limits are not
+  configured. A public account that becomes private is removed from the pool.
+- **Bridge caches and request limits:** retained only for their configured
+  cache or rate-limit window. Hosting-platform logs may follow the hosting
+  provider's operational retention settings.
+- **Buffer content:** retained under the user's Buffer account and Buffer's
+  policies until deleted or otherwise expired there.
+- **Cloudinary media:** retained by the configured Cloudinary account until
+  deleted by that account's operator. It is not automatically deleted when a
+  Twidget draft or Buffer post is removed.
+
+Limited records may be retained when reasonably necessary to comply with law,
+resolve disputes, prevent abuse, or enforce applicable agreements.
+
+## Your choices and rights
+
+Users can:
+
+- use direct FxTwitter mode without joining shared history;
+- turn shared-history contribution on or off in Settings;
+- choose a different data provider or a self-hosted bridge;
+- use local reminders instead of Buffer;
+- disconnect Buffer and remove its local OAuth tokens;
+- remove a tracked account and its local history;
+- clear cached app data through Android; and
+- request deletion of information controlled by the maintainer.
+
+Depending on local law, users may also have rights to access, correct, object
+to processing of, restrict, or receive a copy of their personal information.
+
+## Data deletion requests
+
+Twidget does not create user accounts. To request deletion of a public
+X/Twitter account's shared bridge history, contributed Top Followers ranking,
+related bridge metadata, or media uploaded to the maintainer-operated
+Cloudinary account, contact **That Josh Guy** through
+[support@tjg.gg](mailto:support@tjg.gg).
+
+Identify the X/Twitter username to remove and, for a Cloudinary attachment,
+provide its public Cloudinary URL. Do not send passwords, API keys, OAuth
+tokens, or bridge administration tokens. The maintainer may ask for reasonable
+information to locate the data and prevent fraudulent deletion requests.
+
+Deleting information from Twidget's bridge does not delete the corresponding
+public X/Twitter account or data held independently by X, Buffer, Cloudinary,
+or another provider. Requests concerning a user-configured service or account
+must be directed to that service's operator.
+
+## Children
+
+Twidget is not designed for children and does not knowingly collect personal
+information from children. If you believe a child has provided personal
+information to a maintainer-operated service, use the contact method above to
+request its deletion.
+
+## Changes to this policy
+
+This policy may be updated when Twidget's features, providers, or legal
+obligations change. The effective date at the top will be revised when a new
+version is published. Material changes will be described through the app,
+release notes, or the published policy page where appropriate.
+
+## Contact
+
+The privacy contact and data controller for maintainer-operated Twidget
+services is:
+
+**That Josh Guy**
+
+Support and privacy requests: [support@tjg.gg](mailto:support@tjg.gg)
+
+General contact: [email@tjg.gg](mailto:email@tjg.gg)
+
+Website: [https://tjg.gg](https://tjg.gg)
+
+For the quickest handling, state that the request concerns **Twidget privacy**
+and include only the information needed to identify the relevant data.

--- a/app/src/main/java/com/tjg/twidget/main/AboutActivity.kt
+++ b/app/src/main/java/com/tjg/twidget/main/AboutActivity.kt
@@ -84,6 +84,9 @@ class AboutActivity : FoldablePopOverActivity() {
         findViewById<View>(R.id.about_oneui_credit).setOnClickListener {
             openUrl(getString(R.string.link_oneui_project))
         }
+        findViewById<View>(R.id.about_privacy_policy).setOnClickListener {
+            openUrl(getString(R.string.link_privacy_policy))
+        }
         findViewById<View>(R.id.about_open_source_licenses).setOnClickListener {
             showOpenSourceLicenses()
         }

--- a/app/src/main/res/layout/activity_about.xml
+++ b/app/src/main/res/layout/activity_about.xml
@@ -285,11 +285,21 @@
                 android:orientation="vertical">
 
                 <dev.oneuiproject.oneui.widget.CardItemView
-                    android:id="@+id/about_open_source_licenses"
+                    android:id="@+id/about_privacy_policy"
                     android:layout_width="match_parent"
                     android:layout_height="wrap_content"
                     android:clickable="true"
                     app:showTopDivider="false"
+                    app:summary="@string/about_privacy_policy_summary"
+                    app:summaryMaxLines="3"
+                    app:title="@string/about_privacy_policy_title" />
+
+                <dev.oneuiproject.oneui.widget.CardItemView
+                    android:id="@+id/about_open_source_licenses"
+                    android:layout_width="match_parent"
+                    android:layout_height="wrap_content"
+                    android:clickable="true"
+                    app:showTopDivider="true"
                     app:summary="@string/about_open_source_licenses_summary"
                     app:summaryMaxLines="6"
                     app:title="@string/about_open_source_licenses_title" />

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -269,6 +269,8 @@
     <string name="about_fxtwitter_summary">Default data source. Public profile, status, media, and recent-post analytics data</string>
     <string name="about_oneui_summary">One UI interface components. The magic behind the app\'s design</string>
     <string name="about_legal_section">Legal</string>
+    <string name="about_privacy_policy_title">Privacy policy</string>
+    <string name="about_privacy_policy_summary">How Twidget handles, protects and deletes information</string>
     <string name="about_open_source_licenses_title">Open Source Licences</string>
     <string name="about_open_source_licenses_summary">Apache License 2.0 • MIT License • BSD 3-Clause License • SIL Open Font License 1.1</string>
     <string name="about_legal_notice_title">Legal notice</string>
@@ -294,6 +296,7 @@
     <string name="link_oneui_project">https://github.com/OneUIProject</string>
     <string name="link_rettiwt">https://github.com/Rishikant181/Rettiwt-API</string>
     <string name="link_app_repo">https://github.com/thatjoshguy67/twidget</string>
+    <string name="link_privacy_policy">https://tjg.gg/blog/twidget-privacy-policy</string>
     <string name="sync_failed">Sync failed; showing cached stats.</string>
     <string name="onboarding_title">Twidget</string>
     <string name="onboarding_overview_title">Welcome to Twidget</string>

--- a/docs/play-console/DATA_SAFETY_AUDIT.md
+++ b/docs/play-console/DATA_SAFETY_AUDIT.md
@@ -1,0 +1,103 @@
+# Google Play Data safety audit
+
+Audited against the Android app and bundled bridge source on 26 July 2026.
+The accompanying `data-safety.csv` is based on Google Play's official sample
+CSV downloaded on that date.
+
+## Recommended top-level answers
+
+- Does the app collect or share required user data types? **Yes**
+- Is all collected user data encrypted in transit? **Yes**
+- Can users request deletion? **Yes**
+- Supported Twidget account-creation methods: **The app does not allow users
+  to create an account**
+- Can users connect an account created outside the app? **Yes — Other**
+  (an optional existing Buffer account connected through Buffer OAuth)
+
+The deletion answer relies on the deletion-request route documented in
+`PRIVACY.md`: users contact the maintainer at `support@tjg.gg` and identify the
+X/Twitter username to remove from the maintainer-operated shared bridge.
+The CSV supplies the public privacy policy and deletion instructions at
+`https://tjg.gg/blog/twidget-privacy-policy`.
+
+Connecting Buffer does not create a Twidget account. Buffer owns the external
+account and its sign-in flow; Twidget receives delegated OAuth access only for
+the optional scheduling feature.
+
+## Selected data types
+
+| Play data type | Handling | Ephemeral | Required? | Purpose | Code basis |
+| --- | --- | --- | --- | --- | --- |
+| Name | Collected | No | Optional | App functionality | An opt-in completed Top Followers ranking contributes the public names of up to five ranked accounts to the shared bridge. |
+| Personal identifiers | Collected and shared | No | Required | App functionality | The configured X/Twitter account name is sent to the selected profile provider and may be retained by the opt-in shared-history bridge. Automatic refreshes mean provider transfers are not always a single user-initiated sharing action. Buffer account/channel identifiers are also used when that optional integration is enabled. |
+| Photos | Collected | No | Optional | App functionality | A user-selected image attached to a Buffer post is uploaded to Cloudinary and retained for Buffer to fetch. |
+| Videos | Collected | No | Optional | App functionality | A user-selected video attached to a Buffer post is uploaded to Cloudinary and retained for Buffer to fetch. |
+| Contacts | Collected | No | Optional | App functionality | Google's definition includes social-graph usernames. With shared history enabled, the public Top Followers social-graph ranking can be stored in the shared bridge. |
+| Other user-generated content | Collected | No | Optional | App functionality | Post and thread text explicitly saved or scheduled through Buffer is transmitted to Buffer. Local-reminder drafts remain on-device. |
+| Device or other identifiers | Collected | No | Required | Fraud prevention, security and compliance | The maintainer-operated bridge uses the request IP address as the key for abuse-prevention rate limits, retained across requests for the configured rate-limit window. It is not used to infer location. |
+
+Only **Personal identifiers** is marked shared. Direct, recurring account
+lookups can transmit an account name to an independently operated data
+provider. The other third-party transfers are excluded from "sharing" under
+Google's service-provider or specific user-initiated-action rules:
+
+- Cloudinary processes explicitly selected Buffer attachments to produce URLs
+  that Buffer can fetch.
+- Buffer receives content only when the user explicitly chooses its remote
+  save/schedule functionality.
+- Shared-history and Top Followers contributions are sent to the first-party
+  bridge after a specific opt-in; the in-app disclosure explains that public
+  account stats are contributed for use by other Twidget users.
+
+## Intentionally not selected
+
+- **Location:** no location permission or location API; the bridge does not use
+  IP addresses to infer location.
+- **Email address:** Buffer returns the connected account email to the app, but
+  the app does not transmit that email off-device.
+- **Financial, health, messages, audio, calendar:** no corresponding access or
+  transmission.
+- **Files and docs:** the X Analytics CSV is read locally. When bridge-backed
+  import is active, the app transmits parsed dates and follow/unfollow counts,
+  not the file or its metadata.
+- **Page views and taps, search history, other actions:** there is no off-device
+  product analytics or interaction telemetry.
+- **Crash logs, diagnostics, performance data:** there is no crash-reporting or
+  telemetry SDK. The hidden bridge debug log is opt-in and on-device only.
+- **Installed apps:** package visibility queries are used locally to resolve
+  browsers, X, and Samsung Gallery; results are not transmitted.
+
+## Security and retention evidence
+
+- All built-in endpoints that receive disclosed data use HTTPS. Android's
+  target-SDK cleartext default also blocks an unconfigured HTTP self-hosted
+  endpoint.
+- Android cloud backup and device transfer are disabled for app-private data.
+- API keys and OAuth credentials are protected with Android
+  Keystore-backed encryption on-device.
+- Shared-history retention is operator-configurable. A protected bridge
+  administration endpoint permanently deletes a username's stored history,
+  samples, and metadata.
+- Local account deletion removes app-managed local profile/history, and
+  uninstalling removes app-private data under normal Android behaviour.
+
+## Evidence locations
+
+- `app/src/main/AndroidManifest.xml`
+- `app/build.gradle.kts`
+- `app/src/main/java/com/tjg/twidget/bridge/HistoryPool.kt`
+- `app/src/main/java/com/tjg/twidget/followers/TopFollowersBridgeCache.kt`
+- `app/src/main/java/com/tjg/twidget/schedule/BufferClient.kt`
+- `app/src/main/java/com/tjg/twidget/schedule/BufferMediaUploader.kt`
+- `app/src/main/java/com/tjg/twidget/analytics/AnalyticsImportActivity.kt`
+- `app/src/main/java/com/tjg/twidget/data/SecureCredentialStore.kt`
+- `bridge/src/server.js`
+- `bridge/src/infrastructure.js`
+- `PRIVACY.md`
+
+## Submission note
+
+Importing a CSV overwrites answers already entered in the form. Review the
+store-listing preview after import. If Play Console has changed its schema and
+rejects this file, export a fresh blank/current CSV from that app's Data safety
+page and transfer the same answers above into that export.

--- a/docs/play-console/data-safety.csv
+++ b/docs/play-console/data-safety.csv
@@ -1,0 +1,2246 @@
+Question ID (machine readable),Response ID (machine readable),Response value,Answer requirement,Human-friendly question label
+PSL_DATA_COLLECTION_COLLECTS_PERSONAL_DATA,,TRUE,REQUIRED,Does your app collect or share any of the required user data types?
+PSL_DATA_COLLECTION_ENCRYPTED_IN_TRANSIT,,TRUE,MAYBE_REQUIRED,Is all of the user data collected by your app encrypted in transit?
+PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_USER_ID_PASSWORD,"",MULTIPLE_CHOICE,"Which of the following methods of account creation does your app support?
+Select all that apply
+Username and password"
+PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_USER_ID_OTHER_AUTH,"",MULTIPLE_CHOICE,"Which of the following methods of account creation does your app support?
+Select all that apply
+Username and other authentication"
+PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_USER_ID_PASSWORD_OTHER_AUTH,"",MULTIPLE_CHOICE,"Which of the following methods of account creation does your app support?
+Select all that apply
+Username, password, and other authentication"
+PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_OAUTH,"",MULTIPLE_CHOICE,"Which of the following methods of account creation does your app support?
+Select all that apply
+OAuth"
+PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_OTHER,"",MULTIPLE_CHOICE,"Which of the following methods of account creation does your app support?
+Select all that apply
+Other"
+PSL_SUPPORTED_ACCOUNT_CREATION_METHODS,PSL_ACM_NONE,TRUE,MULTIPLE_CHOICE,"Which of the following methods of account creation does your app support?
+Select all that apply
+My app does not allow users to create an account"
+PSL_ACM_SPECIFY,"","",MAYBE_REQUIRED,Describe the method of account creation that your app supports
+PSL_ACCOUNT_DELETION_URL,"","",MAYBE_REQUIRED,Add a link that users can use to request that their account and associated data is deleted
+PSL_SUPPORT_DATA_DELETION_BY_USER,DATA_DELETION_YES,TRUE,SINGLE_CHOICE,"Do you provide a way for users to request that their data is deleted?
+Yes"
+PSL_SUPPORT_DATA_DELETION_BY_USER,DATA_DELETION_NO,"",SINGLE_CHOICE,"Do you provide a way for users to request that their data is deleted?
+No"
+PSL_SUPPORT_DATA_DELETION_BY_USER,DATA_DELETION_NO_AUTO_DELETED,"",SINGLE_CHOICE,"Do you provide a way for users to request that their data is deleted?
+No, but user data is automatically deleted within 90 days"
+PSL_DATA_DELETION_URL,"",https://tjg.gg/blog/twidget-privacy-policy,MAYBE_REQUIRED,Delete data URL
+PSL_DATA_COLLECTION_COMPLIES_FAMILY_POLICY,"","",OPTIONAL,Only answer if the app is committed to follow the Play Families policy
+PSL_INDEPENDENTLY_VALIDATED,"","",OPTIONAL,Has the app completed an independent MASA security review?
+PSL_UPI_BADGE_OPT_IN,"","",OPTIONAL,Do you want to show the UPI badge on the store listing?
+PSL_HAS_OUTSIDE_APP_ACCOUNTS,"",TRUE,OPTIONAL,Can users login to your app with accounts created outside of the app?
+PSL_OUTSIDE_APP_ACCOUNT_TYPES,PSL_LOGIN_WITH_OUTSIDE_APP_ID,"",MULTIPLE_CHOICE,"How are these accounts created?
+Out of app identification (e.g. SIM binding, service subscription)"
+PSL_OUTSIDE_APP_ACCOUNT_TYPES,PSL_LOGIN_THROUGH_EMPLOYMENT_OR_ENTERPRISE_ACCOUNT,"",MULTIPLE_CHOICE,"How are these accounts created?
+Through employment, or enterprise accounts"
+PSL_OUTSIDE_APP_ACCOUNT_TYPES,PSL_OUTSIDE_APP_ACCOUNT_TYPE_OTHER,TRUE,MULTIPLE_CHOICE,"How are these accounts created?
+Other"
+PSL_OUTSIDE_APP_ACCOUNT_TYPE_SPECIFY,"","Users may optionally connect an existing Buffer account through Buffer OAuth. Twidget does not create or own that account, and the app works without it.",MAYBE_REQUIRED,Describe how these accounts are created
+PSL_DATA_COLLECTION_USER_REQUEST_DELETE,,TRUE,MAYBE_REQUIRED,Do you provide a way for users to request that their data is deleted?
+PSL_DATA_TYPES_PERSONAL,PSL_NAME,TRUE,MULTIPLE_CHOICE,"Personal info
+Name"
+PSL_DATA_TYPES_PERSONAL,PSL_EMAIL,"",MULTIPLE_CHOICE,"Personal info
+Email address"
+PSL_DATA_TYPES_PERSONAL,PSL_USER_ACCOUNT,TRUE,MULTIPLE_CHOICE,"Personal info
+Personal identifiers"
+PSL_DATA_TYPES_PERSONAL,PSL_ADDRESS,"",MULTIPLE_CHOICE,"Personal info
+Address"
+PSL_DATA_TYPES_PERSONAL,PSL_PHONE,"",MULTIPLE_CHOICE,"Personal info
+Phone number"
+PSL_DATA_TYPES_PERSONAL,PSL_RACE_ETHNICITY,"",MULTIPLE_CHOICE,"Personal info
+Race and ethnicity"
+PSL_DATA_TYPES_PERSONAL,PSL_POLITICAL_RELIGIOUS,"",MULTIPLE_CHOICE,"Personal info
+Political or religious beliefs"
+PSL_DATA_TYPES_PERSONAL,PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY,"",MULTIPLE_CHOICE,"Personal info
+Sexual orientation or gender identity"
+PSL_DATA_TYPES_PERSONAL,PSL_OTHER_PERSONAL,"",MULTIPLE_CHOICE,"Personal info
+Other personal info"
+PSL_DATA_TYPES_FINANCIAL,PSL_PURCHASE_HISTORY,"",MULTIPLE_CHOICE,"Financial info
+Purchase history"
+PSL_DATA_TYPES_FINANCIAL,PSL_CREDIT_SCORE,"",MULTIPLE_CHOICE,"Financial info
+Credit info"
+PSL_DATA_TYPES_FINANCIAL,PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER,"",MULTIPLE_CHOICE,"Financial info
+Credit card, debit card, or bank account number"
+PSL_DATA_TYPES_FINANCIAL,PSL_OTHER,"",MULTIPLE_CHOICE,"Financial info
+Other financial info"
+PSL_DATA_TYPES_LOCATION,PSL_APPROX_LOCATION,"",MULTIPLE_CHOICE,"Location
+Approximate location"
+PSL_DATA_TYPES_LOCATION,PSL_PRECISE_LOCATION,"",MULTIPLE_CHOICE,"Location
+Precise location"
+PSL_DATA_TYPES_SEARCH_AND_BROWSING,PSL_WEB_BROWSING_HISTORY,"",MULTIPLE_CHOICE,"Web browsing
+Web browsing history"
+PSL_DATA_TYPES_EMAIL_AND_TEXT,PSL_EMAILS,"",MULTIPLE_CHOICE,"Messages
+Emails"
+PSL_DATA_TYPES_EMAIL_AND_TEXT,PSL_SMS_CALL_LOG,"",MULTIPLE_CHOICE,"Messages
+SMS or MMS messages"
+PSL_DATA_TYPES_EMAIL_AND_TEXT,PSL_OTHER_MESSAGES,"",MULTIPLE_CHOICE,"Messages
+Other in-app messages"
+PSL_DATA_TYPES_PHOTOS_AND_VIDEOS,PSL_PHOTOS,TRUE,MULTIPLE_CHOICE,"Photos and videos
+Photos"
+PSL_DATA_TYPES_PHOTOS_AND_VIDEOS,PSL_VIDEOS,TRUE,MULTIPLE_CHOICE,"Photos and videos
+Videos"
+PSL_DATA_TYPES_AUDIO,PSL_AUDIO,"",MULTIPLE_CHOICE,"Audio files
+Voice or sound recordings"
+PSL_DATA_TYPES_AUDIO,PSL_MUSIC,"",MULTIPLE_CHOICE,"Audio files
+Music files"
+PSL_DATA_TYPES_AUDIO,PSL_OTHER_AUDIO,"",MULTIPLE_CHOICE,"Audio files
+Other audio files"
+PSL_DATA_TYPES_HEALTH_AND_FITNESS,PSL_HEALTH,"",MULTIPLE_CHOICE,"Health and fitness
+Health information"
+PSL_DATA_TYPES_HEALTH_AND_FITNESS,PSL_FITNESS,"",MULTIPLE_CHOICE,"Health and fitness
+Fitness information"
+PSL_DATA_TYPES_CONTACTS,PSL_CONTACTS,TRUE,MULTIPLE_CHOICE,"Contacts
+Contacts"
+PSL_DATA_TYPES_CALENDAR,PSL_CALENDAR,"",MULTIPLE_CHOICE,"Calendar
+Calendar events"
+PSL_DATA_TYPES_APP_PERFORMANCE,PSL_CRASH_LOGS,"",MULTIPLE_CHOICE,"App info and performance
+Crash logs"
+PSL_DATA_TYPES_APP_PERFORMANCE,PSL_PERFORMANCE_DIAGNOSTICS,"",MULTIPLE_CHOICE,"App info and performance
+Diagnostics"
+PSL_DATA_TYPES_APP_PERFORMANCE,PSL_OTHER_PERFORMANCE,"",MULTIPLE_CHOICE,"App info and performance
+Other app performance data"
+PSL_DATA_TYPES_FILES_AND_DOCS,PSL_FILES_AND_DOCS,"",MULTIPLE_CHOICE,"Files and docs
+Files and docs"
+PSL_DATA_TYPES_APP_ACTIVITY,PSL_USER_INTERACTION,"",MULTIPLE_CHOICE,"App activity
+Page views and taps in app"
+PSL_DATA_TYPES_APP_ACTIVITY,PSL_IN_APP_SEARCH_HISTORY,"",MULTIPLE_CHOICE,"App activity
+In-app search history"
+PSL_DATA_TYPES_APP_ACTIVITY,PSL_APPS_ON_DEVICE,"",MULTIPLE_CHOICE,"App activity
+Installed apps"
+PSL_DATA_TYPES_APP_ACTIVITY,PSL_USER_GENERATED_CONTENT,TRUE,MULTIPLE_CHOICE,"App activity
+Other user-generated content"
+PSL_DATA_TYPES_APP_ACTIVITY,PSL_OTHER_APP_ACTIVITY,"",MULTIPLE_CHOICE,"App activity
+Other actions"
+PSL_DATA_TYPES_IDENTIFIERS,PSL_DEVICE_ID,TRUE,MULTIPLE_CHOICE,"Device or other identifiers
+Device or other identifiers"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Name)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:PSL_DATA_USAGE_EPHEMERAL,,FALSE,MAYBE_REQUIRED,"Data usage and handling (Name)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,TRUE,SINGLE_CHOICE,"Data usage and handling (Name)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Name)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_NAME:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Name)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Email address)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Email address)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Email address)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAIL:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Email address)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:PSL_DATA_USAGE_EPHEMERAL,,FALSE,MAYBE_REQUIRED,"Data usage and handling (Personal identifiers)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Personal identifiers)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,TRUE,SINGLE_CHOICE,"Data usage and handling (Personal identifiers)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_ACCOUNT:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Personal identifiers)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Address)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Address)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Address)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_ADDRESS:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Address)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Phone number)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Phone number)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Phone number)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_PHONE:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Phone number)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Race and ethnicity)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_RACE_ETHNICITY:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Race and ethnicity)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Political or religious beliefs)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_POLITICAL_RELIGIOUS:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Political or religious beliefs)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Sexual orientation or gender identity)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_SEXUAL_ORIENTATION_GENDER_IDENTITY:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Sexual orientation or gender identity)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Other personal info)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Other personal info)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Other personal info)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERSONAL:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other personal info)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Purchase history)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Purchase history)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Purchase history)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_PURCHASE_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Purchase history)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Credit info)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Credit info)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Credit info)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_SCORE:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Credit info)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Credit card, debit card, or bank account number)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_CREDIT_DEBIT_BANK_ACCOUNT_NUMBER:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Credit card, debit card, or bank account number)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Other financial info)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Other financial info)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Other financial info)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other financial info)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Approximate location)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Approximate location)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Approximate location)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_APPROX_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Approximate location)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Precise location)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Precise location)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Precise location)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_PRECISE_LOCATION:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Precise location)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Web browsing history)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Web browsing history)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Web browsing history)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_WEB_BROWSING_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Web browsing history)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Emails)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Emails)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Emails)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_EMAILS:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Emails)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (SMS or MMS messages)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_SMS_CALL_LOG:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (SMS or MMS messages)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Other in-app messages)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Other in-app messages)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Other in-app messages)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_MESSAGES:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other in-app messages)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:PSL_DATA_USAGE_EPHEMERAL,,FALSE,MAYBE_REQUIRED,"Data usage and handling (Photos)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,TRUE,SINGLE_CHOICE,"Data usage and handling (Photos)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Photos)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_PHOTOS:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Photos)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:PSL_DATA_USAGE_EPHEMERAL,,FALSE,MAYBE_REQUIRED,"Data usage and handling (Videos)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,TRUE,SINGLE_CHOICE,"Data usage and handling (Videos)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Videos)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_VIDEOS:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Videos)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Voice or sound recordings)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Voice or sound recordings)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Music files)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Music files)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Music files)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_MUSIC:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Music files)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Other audio files)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Other audio files)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Other audio files)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_AUDIO:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other audio files)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Health information)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Health information)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Health information)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_HEALTH:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Health information)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Fitness information)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Fitness information)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Fitness information)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_FITNESS:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Fitness information)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:PSL_DATA_USAGE_EPHEMERAL,,FALSE,MAYBE_REQUIRED,"Data usage and handling (Contacts)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,TRUE,SINGLE_CHOICE,"Data usage and handling (Contacts)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Contacts)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_CONTACTS:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Contacts)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Calendar events)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Calendar events)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Calendar events)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_CALENDAR:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Calendar events)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Crash logs)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Crash logs)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Crash logs)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_CRASH_LOGS:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Crash logs)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Diagnostics)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Diagnostics)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Diagnostics)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_PERFORMANCE_DIAGNOSTICS:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Diagnostics)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Other app performance data)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Other app performance data)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Other app performance data)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_PERFORMANCE:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other app performance data)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Files and docs)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Files and docs)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Files and docs)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_FILES_AND_DOCS:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Files and docs)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Page views and taps in app)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_INTERACTION:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Page views and taps in app)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (In-app search history)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (In-app search history)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (In-app search history)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_IN_APP_SEARCH_HISTORY:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (In-app search history)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Installed apps)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Installed apps)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Installed apps)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_APPS_ON_DEVICE:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Installed apps)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:PSL_DATA_USAGE_EPHEMERAL,,FALSE,MAYBE_REQUIRED,"Data usage and handling (Other user-generated content)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,TRUE,SINGLE_CHOICE,"Data usage and handling (Other user-generated content)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Other user-generated content)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_USER_GENERATED_CONTENT:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other user-generated content)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:PSL_DATA_USAGE_EPHEMERAL,,"",MAYBE_REQUIRED,"Data usage and handling (Other actions)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Other actions)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,"",SINGLE_CHOICE,"Data usage and handling (Other actions)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_OTHER_APP_ACTIVITY:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Other actions)
+Why is this user data shared? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_COLLECTED,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Is this data collected, shared, or both?
+Collected"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:PSL_DATA_USAGE_COLLECTION_AND_SHARING,PSL_DATA_USAGE_ONLY_SHARED,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Is this data collected, shared, or both?
+Shared"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:PSL_DATA_USAGE_EPHEMERAL,,FALSE,MAYBE_REQUIRED,"Data usage and handling (Device or other identifiers)
+Is this data processed ephemerally?"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_OPTIONAL,"",SINGLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Is this data required for your app, or can users choose whether it's collected?
+Users can choose whether this data is collected"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_USER_CONTROL,PSL_DATA_USAGE_USER_CONTROL_REQUIRED,TRUE,SINGLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Is this data required for your app, or can users choose whether it's collected?
+Data collection is required (users can't turn off this data collection)"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_COLLECTION_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data collected? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_COLLECTION_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data collected? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_COLLECTION_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data collected? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_COLLECTION_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,TRUE,MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data collected? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_COLLECTION_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data collected? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_COLLECTION_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data collected? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_COLLECTION_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data collected? Select all that apply.
+Account management"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_SHARING_PURPOSE,PSL_APP_FUNCTIONALITY,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data shared? Select all that apply.
+App functionality"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_SHARING_PURPOSE,PSL_ANALYTICS,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data shared? Select all that apply.
+Analytics"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_SHARING_PURPOSE,PSL_DEVELOPER_COMMUNICATIONS,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data shared? Select all that apply.
+Developer communications"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_SHARING_PURPOSE,PSL_FRAUD_PREVENTION_SECURITY,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data shared? Select all that apply.
+Fraud prevention, security, and compliance"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_SHARING_PURPOSE,PSL_ADVERTISING,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data shared? Select all that apply.
+Advertising or marketing"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_SHARING_PURPOSE,PSL_PERSONALIZATION,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data shared? Select all that apply.
+Personalization"
+PSL_DATA_USAGE_RESPONSES:PSL_DEVICE_ID:DATA_USAGE_SHARING_PURPOSE,PSL_ACCOUNT_MANAGEMENT,"",MULTIPLE_CHOICE,"Data usage and handling (Device or other identifiers)
+Why is this user data shared? Select all that apply.
+Account management"


### PR DESCRIPTION
## Summary

- add an in-app privacy-policy entry in About
- publish the expanded Twidget privacy policy
- document the audited Google Play Data safety responses and import CSV

## Why

Google Play production submission requires a public privacy policy and an in-app policy link. This also records the data-handling declarations used for the Play Console submission.

## Validation

- manually verified the About-screen privacy link
- `:app:compileDebugKotlin :app:lintDebug :app:assembleDebug`
- staging Debug Build workflow passed, including signed APK/AAB verification and bridge checks