### PR TITLE
Fixes and corrections

### DIFF
--- a/app/src/main/java/com/tjg/twidget/widget/LockScreenFollowerWidgets.kt
+++ b/app/src/main/java/com/tjg/twidget/widget/LockScreenFollowerWidgets.kt
@@ -174,9 +174,12 @@ object LockScreenFollowerViews {
         val locale = AppLocales.resolve(widgetSettings.language)
         val count = AppLocales.integer(stats.followersCount, locale)
         val strings = AppLocales.wrap(context, widgetSettings.language)
+        val rawFollowers = strings.getString(R.string.followers)
         val deltaText = when {
             !widgetSettings.showDelta -> ""
-            delta == 0L -> strings.getString(R.string.followers).lowercase()
+            delta == 0L -> {
+                if (locale.language == "de") rawFollowers else rawFollowers.lowercase()
+            }
             else -> TwidgetStore.signedNumber(delta)
         }
         // Transparent widget over the wallpaper, so text is white like the

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -4,7 +4,7 @@
     <string name="widget_description">Twitter Follower-Tracker mit Blur-Widgets</string>
     <string name="widget_label">Twidget Follower</string>
     <string name="widget_language">Sprache</string>
-    <string name="widget_language_default">Systemstandard</string>
+    <string name="widget_language_default">App-Standard</string>
     <string name="widget_language_de">Deutsch</string>
     <string name="widget_language_en">Englisch (English)</string>
     <string name="lockscreen_follower_1x1_label">Follower 1x1</string>
@@ -327,7 +327,7 @@
     <string name="update_notification_title">Twidget-Update verfügbar</string>
     <string name="update_notification_body">Version %1$s ist bereit zur Installation.</string>
     <string name="update_notification_channel_description">Benachrichtigen, wenn eine neue Version von Twidget verfügbar ist</string>
-    <string name="update_remind_later">Erinnere mich später</string>
+    <string name="update_remind_later">Später erinnern</string>
     <string name="update_install_now">Jetzt installieren</string>
     <string name="oneui_project">One UI Project</string>
     <string name="link_tjg">https://tjg.gg</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -4,7 +4,7 @@
     <string name="widget_description">X/Twitter follower tracker with blurred home screen widgets</string>
     <string name="widget_label">Twidget Followers</string>
     <string name="widget_language">Language</string>
-    <string name="widget_language_default">System default</string>
+    <string name="widget_language_default">App default</string>
     <string name="widget_language_de">German (Deutsch)</string>
     <string name="widget_language_en">English</string>
     <string name="lockscreen_follower_1x1_label">Followers 1x1</string>


### PR DESCRIPTION
### Fixes

- Fixed lowercase formatting for the "show delta" option on both lock screen widgets (german only)
- Corrected the default language label in the widget settings from "System default" / "Systemstandard" to "App default" / "App-Standard" (both languages)
- Shortened the update notification in german so it doesn't get cut off (german only)
(Possibly more to come in the following days as I couldn't test out every new german string yet)
